### PR TITLE
fix: use canonical opm.* entry-point group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "ovos-ddg-plugin>=0.1.0a1,<2.0.0",
 ]
 
-[project.entry-points."ovos.plugin.skill"]
+[project.entry-points."opm.skill"]
 "ovos-skill-ddg.openvoiceos" = "ovos_skill_ddg:DuckDuckGoSkill"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     "ovos-utils>=0.7.0,<1.0.0",
     "ovos-workshop>=8.0.0,<9.0.0",
-    "ovos-plugin-manager>=2.3.0a1,<3.0.0",
+    "ovos-plugin-manager>=2.4.0a1",
     "ovos-ddg-plugin>=0.1.0a1,<2.0.0",
 ]
 


### PR DESCRIPTION
Modernize the plugin's entry-point group from the deprecated `ovos.plugin.skill` to the canonical `opm.skill` (PluginTypes value in ovos-plugin-manager). The loader aliases the old name, but the canonical group is the current standard.