### PR TITLE
fix: require ovos-plugin-manager>=2.1.0 for opm.* entry points and cap ovos-* deps at next major

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     "ovos-utils>=0.7.0,<1.0.0",
     "ovos-workshop>=8.0.0,<9.0.0",
-    "ovos-plugin-manager>=2.4.0a1",
+    "ovos-plugin-manager>=2.1.0,<3.0.0",
     "ovos-ddg-plugin>=0.1.0a1,<2.0.0",
 ]
 
@@ -31,7 +31,7 @@ version = {attr = "ovos_skill_ddg.version.__version__"}
 
 [project.optional-dependencies]
 test = [
-    "ovoscope",
+    "ovoscope<1.0.0",
     "ovos-ddg-plugin>=0.1.0a1,<2.0.0",
 ]
 


### PR DESCRIPTION
The `opm.*` entry-point group(s) declared by this package are only recognized by `ovos-plugin-manager>=2.1.0` (canonical in PluginTypes since 2.1.0; `opm.agents.*` since 2.3.0a1). An older plugin-manager queries the legacy entry-point group and silently never discovers the plugin. Also caps all `ovos-*` dependencies at the next major so the latest published versions resolve.