### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # <img src='./gui/all/ddg.png' card_color='#de5833' width='50' height='50' style='vertical-align:bottom'/> DuckDuckGo
 
-Answer factual questions using [DuckDuckGo Instant Answers](https://duckduckgo.com/api).
-
-Powered by [ovos-ddg-plugin](https://github.com/OpenVoiceOS/ovos-ddg-plugin).
+This OVOS skill answers factual questions with [DuckDuckGo Instant Answers](https://duckduckgo.com/api). It uses [ovos-ddg-plugin](https://github.com/OpenVoiceOS/ovos-ddg-plugin) to query the API and extract facts from the results.
 
 ![](./gui/all/logo.png)
+
+## Install
+
+```bash
+pip install ovos-skill-ddg
+```
 
 ## Examples
 
@@ -16,26 +20,31 @@ Powered by [ovos-ddg-plugin](https://github.com/OpenVoiceOS/ovos-ddg-plugin).
 
 ## How it works
 
-The skill participates in three OVOS pipeline stages:
+The skill takes part in three OVOS pipeline stages.
 
 | Pipeline | Trigger | Priority |
 |---|---|---|
 | **Padacioso intent** (`search_duck.intent`) | Explicit "search DuckDuckGo for …" phrases | High |
-| **Common Query** | Open factual questions routed by the common-query pipeline | — |
+| **Common Query** | Open factual questions routed by the common-query pipeline | none |
 | **Fallback** | Any utterance not claimed by another skill | 90 (last resort) |
 
-Queries are forwarded to the DuckDuckGo Instant Answers API via [ovos-ddg-plugin](https://github.com/OpenVoiceOS/ovos-ddg-plugin), which handles:
+The skill sends queries to the DuckDuckGo Instant Answers API through [ovos-ddg-plugin](https://github.com/OpenVoiceOS/ovos-ddg-plugin). The plugin handles:
 
-- **Infobox field extraction** — structured facts (birthdate, nationality, occupation, …) matched via locale-aware Padacioso intents
-- **Abstract text** — encyclopaedic summary sentences
-- **Keyword extraction fallback** — when a conversational phrase returns no result, keywords are extracted and re-queried (requires `ovos-rake-keyword-extractor` or compatible plugin)
+- **Infobox field extraction**: structured facts (birthdate, nationality, occupation, …) matched with locale-aware Padacioso intents
+- **Abstract text**: encyclopedic summary sentences
+- **Keyword extraction fallback**: when a conversational phrase returns no result, the skill extracts keywords and re-queries (this needs `ovos-rake-keyword-extractor` or a compatible plugin)
 
-Blacklisted domains (weather, reminders, alarms, timers, music, calls) are detected via per-locale vocabulary files and routed to the appropriate skill instead.
+The skill detects blacklisted domains (weather, reminders, alarms, timers, music, calls) with per-locale vocabulary files and routes them to the matching skill instead.
 
 ## Supported languages
 
-37 locales covering all languages in the DuckDuckGo API locale mapping:
-ar, bg, ca, cs, da, de, el, en, es, et, fi, fil, fr, he, hr, hu, id, it, ja, ko, lt, lv, ms, nb, nl, pl, pt, ro, ru, sk, sl, sv, th, tr, uk, vi, zh.
+37 locales cover all languages in the DuckDuckGo API locale mapping.
+
+`ar bg ca cs da de el en es et fi fil fr he hr hu id it ja ko lt lv ms nb nl pl pt ro ru sk sl sv th tr uk vi zh`
+
+## Related projects
+
+* [ovos-ddg-plugin](https://github.com/OpenVoiceOS/ovos-ddg-plugin): the query and answer-extraction backend this skill uses
 
 ## Category
 **Information**
@@ -45,3 +54,7 @@ ar, bg, ca, cs, da, de, el, en, es, et, fi, fil, fr, he, hr, hu, id, it, ja, ko,
 #query
 #search-engine
 #searchengine
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Rewrites the README in Simplified Technical English for clarity: shorter sentences, active voice, and a consistent structure (what it is, install, examples, how it works, related projects, license). All facts, code blocks, and links are preserved; a related-projects link to ovos-ddg-plugin and an install section were added since neither existed before.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation instructions.
  * Documented DuckDuckGo API integration and answer extraction.
  * Added details on processing flow, blacklist routing, supported languages, related projects, and licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->